### PR TITLE
Fix for undefined currentStyle undefined

### DIFF
--- a/lib/fitie.js
+++ b/lib/fitie.js
@@ -1,6 +1,6 @@
 this.fitie = function (node) {
 	// restrict to valid object-fit value
-	var objectFit = node.currentStyle['object-fit'];
+	var objectFit = node.currentStyle ? node.currentStyle['object-fit'] : null;
 
 	if (!objectFit || !/^(contain|cover|fill)$/.test(objectFit)) return;
 


### PR DESCRIPTION
Fixed error in IE 11:
Unable to get property 'object-fit' of undefined or null reference